### PR TITLE
✨feat/상세보기 상단 컴포넌트 생성 및 css 작업

### DIFF
--- a/src/components/DetailStation.tsx
+++ b/src/components/DetailStation.tsx
@@ -1,7 +1,14 @@
 import '../styles/DetailStation.scss';
+import DetailStationLogo from './DetailStationLogo';
+import DetailStationSearchWrap from './DetailStationSearchWrap';
 
 function DetailStation() {
-  return <div className="DetailStationWrap">DetailStation</div>;
+  return (
+    <div className="DetailStationWrap">
+      <DetailStationLogo />
+      <DetailStationSearchWrap />
+    </div>
+  );
 }
 
 export default DetailStation;

--- a/src/components/DetailStationLineButton.tsx
+++ b/src/components/DetailStationLineButton.tsx
@@ -1,5 +1,17 @@
-function DetailStationLineButton() {
-  return <button type="button">2호선</button>;
+interface IDetailStationLineButtonProps {
+  value: string;
+  line: string;
+}
+
+function DetailStationLineButton({
+  value,
+  line,
+}: IDetailStationLineButtonProps) {
+  return (
+    <button type="button" className={`DetailStationLineButton${line}`}>
+      {value}
+    </button>
+  );
 }
 
 export default DetailStationLineButton;

--- a/src/components/DetailStationLineButton.tsx
+++ b/src/components/DetailStationLineButton.tsx
@@ -1,0 +1,5 @@
+function DetailStationLineButton() {
+  return <button type="button">2호선</button>;
+}
+
+export default DetailStationLineButton;

--- a/src/components/DetailStationLineFilter.tsx
+++ b/src/components/DetailStationLineFilter.tsx
@@ -2,10 +2,10 @@ import DetailStationLineButton from './DetailStationLineButton';
 
 function DetailStationLineFilter() {
   return (
-    <div>
-      <DetailStationLineButton />
-      <DetailStationLineButton />
-      <DetailStationLineButton />
+    <div className="DetailStationLineFilter">
+      <DetailStationLineButton value="2호선" line="line2" />
+      <DetailStationLineButton value="4호선" line="line4" />
+      <DetailStationLineButton value="5호선" line="line5" />
     </div>
   );
 }

--- a/src/components/DetailStationLineFilter.tsx
+++ b/src/components/DetailStationLineFilter.tsx
@@ -1,0 +1,13 @@
+import DetailStationLineButton from './DetailStationLineButton';
+
+function DetailStationLineFilter() {
+  return (
+    <div>
+      <DetailStationLineButton />
+      <DetailStationLineButton />
+      <DetailStationLineButton />
+    </div>
+  );
+}
+
+export default DetailStationLineFilter;

--- a/src/components/DetailStationLogo.tsx
+++ b/src/components/DetailStationLogo.tsx
@@ -1,0 +1,5 @@
+function DetailStationLogo() {
+  return <div className="DetailStationLogo">MOOVE</div>;
+}
+
+export default DetailStationLogo;

--- a/src/components/DetailStationSearch.tsx
+++ b/src/components/DetailStationSearch.tsx
@@ -1,7 +1,10 @@
+import { FaSearch } from 'react-icons/fa';
+
 function DetailStationSearch() {
   return (
     <div className="DetailStationSearch">
-      <input />
+      <input className="DetailStationSearchInput" placeholder="역명 검색" />
+      <FaSearch className="DetailStationSearchIcon" size="24" />
     </div>
   );
 }

--- a/src/components/DetailStationSearch.tsx
+++ b/src/components/DetailStationSearch.tsx
@@ -1,0 +1,9 @@
+function DetailStationSearch() {
+  return (
+    <div className="DetailStationSearch">
+      <input />
+    </div>
+  );
+}
+
+export default DetailStationSearch;

--- a/src/components/DetailStationSearchWrap.tsx
+++ b/src/components/DetailStationSearchWrap.tsx
@@ -1,0 +1,13 @@
+import DetailStationLineFilter from './DetailStationLineFilter';
+import DetailStationSearch from './DetailStationSearch';
+
+function DetailStationSearchWrap() {
+  return (
+    <div className="DetailStationSearchWrap">
+      <DetailStationSearch />
+      <DetailStationLineFilter />
+    </div>
+  );
+}
+
+export default DetailStationSearchWrap;

--- a/src/components/DetailStationSearchWrap.tsx
+++ b/src/components/DetailStationSearchWrap.tsx
@@ -1,5 +1,6 @@
 import DetailStationLineFilter from './DetailStationLineFilter';
 import DetailStationSearch from './DetailStationSearch';
+import '../styles/DetailStationSearch.scss';
 
 function DetailStationSearchWrap() {
   return (

--- a/src/styles/DetailStation.scss
+++ b/src/styles/DetailStation.scss
@@ -1,8 +1,17 @@
 .DetailStationWrap {
-  background-color: #F2F2F2;
-  border: 3px solid #D9D9D9;
+  background-color: #f2f2f2;
+  border: 3px solid #d9d9d9;
   border-top-right-radius: 5rem;
   border-bottom-right-radius: 5rem;
   width: 20%;
   min-width: 450px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  .DetailStationLogo {
+    width: 23rem;
+    font-family: 'Squada One', cursive;
+    font-size: 4rem;
+    letter-spacing: 1px;
+  }
 }

--- a/src/styles/DetailStationSearch.scss
+++ b/src/styles/DetailStationSearch.scss
@@ -1,0 +1,62 @@
+.DetailStationSearchWrap {
+  width: 23rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 10% 0;
+  border-bottom: 3px solid rgba(170, 170, 170, 0.5);
+  .DetailStationSearch {
+    width: 23rem;
+    height: 2rem;
+    padding: 1%;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    background-color: white;
+    border-radius: 2rem;
+    .DetailStationSearchInput {
+      width: 100%;
+      height: 1rem;
+      margin: 0 3%;
+      border: none;
+      outline: none;
+    }
+    .DetailStationSearchIcon {
+      margin-right: 5%;
+    }
+  }
+  .DetailStationLineFilter {
+    width: 23rem;
+    padding-top: 8%;
+    padding-bottom: 4%;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    .DetailStationLineButton {
+      @mixin buttonColor($color) {
+        width: 30%;
+        height: 2.5rem;
+        border: none;
+        border-radius: 2rem;
+        color: white;
+        background-color: $color;
+        &:hover {
+          background: lighten($color, 10%);
+        }
+
+        &:active {
+          background: darken($color, 10%);
+        }
+      }
+      &line2 {
+        @include buttonColor(#3db44b);
+      }
+      &line4 {
+        @include buttonColor(#08a5e3);
+      }
+      &line5 {
+        @include buttonColor(#8300eb);
+      }
+    }
+  }
+}


### PR DESCRIPTION
- 상세보기의 내부 태그를 컴포넌트화 하였습니다.
- 컴포넌트화한 자손 컴포넌트에 css 작업을 하였습니다.

![image](https://github.com/sienna0715/moove/assets/115691844/8a9d9128-b1bb-4a5a-a7de-9b99bd14642e)
