### PR TITLE
♻️refactor/header 컴포넌트 분리 및 props 타입 지정

### DIFF
--- a/src/header/DetailStationLineButton.tsx
+++ b/src/header/DetailStationLineButton.tsx
@@ -1,4 +1,4 @@
-import { useRecoilValue, useSetRecoilState } from 'recoil';
+import { useRecoilState } from 'recoil';
 import { useEffect, useState } from 'react';
 // components
 import { lineSelectAtom } from '../recoil/atoms';
@@ -9,19 +9,18 @@ function DetailStationLineButton({
   line,
 }: IDetailStationLineButtonProps) {
   const [isLine, setIsLine] = useState('true');
-  const setLineSelect = useSetRecoilState(lineSelectAtom);
-  const lineSelectValue = useRecoilValue(lineSelectAtom);
+  const [lineSelect, setLineSelect] = useRecoilState(lineSelectAtom);
 
   useEffect(() => {
-    if (lineSelectValue === line || lineSelectValue === '') {
+    if (lineSelect === line || lineSelect === '') {
       setIsLine('true');
     } else {
       setIsLine('false');
     }
-  }, [line, lineSelectValue]);
+  }, [line, lineSelect]);
 
   const lineButtonClickHandler = () => {
-    if (lineSelectValue === line) {
+    if (lineSelect === line) {
       setLineSelect('');
     } else {
       setLineSelect(line);

--- a/src/header/DetailStationLineButton.tsx
+++ b/src/header/DetailStationLineButton.tsx
@@ -2,11 +2,7 @@ import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { useEffect, useState } from 'react';
 // components
 import { lineSelectAtom } from '../recoil/atoms';
-
-interface IDetailStationLineButtonProps {
-  value: string;
-  line: string;
-}
+import { IDetailStationLineButtonProps } from '../interfaces/interfaces';
 
 function DetailStationLineButton({
   value,

--- a/src/header/DetailStationSearch.tsx
+++ b/src/header/DetailStationSearch.tsx
@@ -1,11 +1,9 @@
-import React, { useEffect, useState } from 'react';
-import { FaSearch } from 'react-icons/fa';
-import { useRecoilState, useRecoilValue } from 'recoil';
-import {
-  currentStationAtom,
-  stationNameAtom,
-  isDropdownAtom,
-} from '../recoil/atoms';
+import { useEffect, useState } from 'react';
+
+import { useRecoilValue } from 'recoil';
+import { currentStationAtom, stationNameAtom } from '../recoil/atoms';
+import DetailStationSearchDropdown from './DetailStationSearchDropdown';
+import DetailStationSearchInput from './DetailStationSearchInput';
 
 function DetailStationSearch() {
   const [searchInput, setSearchInput] = useState('');
@@ -13,8 +11,7 @@ function DetailStationSearch() {
   const [filteredStationNames, setFilteredStationNames] = useState<string[]>(
     [],
   );
-  const [currentStation, setCurrentStation] = useRecoilState(currentStationAtom);
-  const [isDropdown, setIsDropdown] = useRecoilState(isDropdownAtom);
+  const currentStation = useRecoilValue(currentStationAtom);
   const stationNameDatas = useRecoilValue(stationNameAtom);
 
   useEffect(() => {
@@ -42,76 +39,18 @@ function DetailStationSearch() {
     stationNameDatas.line4,
     stationNameDatas.line5,
   ]);
-  const searchInputChangeHandler = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setSearchInput(() => e.target.value);
-    if (e.target.value.replace(/(\s*)/g, '') === '') {
-      setFilteredStationNames(stationNames);
-    } else if (e.target.value.replace(/(\s*)/g, '') !== '') {
-      setFilteredStationNames(
-        stationNames.filter((stationName) =>
-          stationName.includes(e.target.value),
-        ),
-      );
-    }
-  };
-
-  const searchClickHandler = () => {
-    setCurrentStation(searchInput.replace(/(\s*)/g, ''));
-  };
-
-  const searchDropdownClickHandler = (stationName: string) => {
-    setCurrentStation(stationName);
-    setIsDropdown(false);
-  };
-
-  const inputOnFocusHandler = () => {
-    setIsDropdown(true);
-  };
-
-  const dropdownCloseHandler = () => {
-    setIsDropdown(false);
-  };
 
   return (
     <div>
-      {isDropdown ? (
-        <div className="DetailStationSearchDropdown">
-          <div className="DetailStationSerchDropdownSpace" />
-          <div className="DetailStationSearchDropdownWapper">
-            {filteredStationNames.map((filteredStationName) => (
-              <div
-                role="presentation"
-                onClick={() => {
-                  searchDropdownClickHandler(filteredStationName);
-                }}
-              >
-                {filteredStationName}
-              </div>
-            ))}
-          </div>
-          <button
-            className="DetailStationSearchDropdownButton"
-            type="button"
-            onClick={dropdownCloseHandler}
-          >
-            x
-          </button>
-        </div>
-      ) : null}
-      <div className="DetailStationSearch">
-        <input
-          className="DetailStationSearchInput"
-          placeholder="역명 검색"
-          onChange={searchInputChangeHandler}
-          value={searchInput}
-          onFocus={inputOnFocusHandler}
-        />
-        <FaSearch
-          className="DetailStationSearchIcon"
-          size="24"
-          onClick={searchClickHandler}
-        />
-      </div>
+      <DetailStationSearchDropdown
+        filteredStationNames={filteredStationNames}
+      />
+      <DetailStationSearchInput
+        searchInput={searchInput}
+        stationNames={stationNames}
+        setSearchInput={setSearchInput}
+        setFilteredStationNames={setFilteredStationNames}
+      />
     </div>
   );
 }

--- a/src/header/DetailStationSearchDropdown.tsx
+++ b/src/header/DetailStationSearchDropdown.tsx
@@ -1,0 +1,51 @@
+import { useRecoilValue, useSetRecoilState } from 'recoil';
+import { isDropdownAtom, currentStationAtom } from '../recoil/atoms';
+import { IDetailStationSearchDropdownProps } from '../interfaces/interfaces';
+
+function DetailStationSearchDropdown({
+  filteredStationNames,
+}: IDetailStationSearchDropdownProps) {
+  const isDropdown = useRecoilValue(isDropdownAtom);
+  const setCurrentStation = useSetRecoilState(currentStationAtom);
+  const setIsDropdown = useSetRecoilState(isDropdownAtom);
+
+  const searchDropdownClickHandler = (stationName: string) => {
+    setCurrentStation(stationName);
+    setIsDropdown(false);
+  };
+
+  const dropdownCloseHandler = () => {
+    setIsDropdown(false);
+  };
+
+  return (
+    <div>
+      {isDropdown ? (
+        <div className="DetailStationSearchDropdown">
+          <div className="DetailStationSerchDropdownSpace" />
+          <div className="DetailStationSearchDropdownWapper">
+            {filteredStationNames.map((filteredStationName) => (
+              <div
+                role="presentation"
+                onClick={() => {
+                  searchDropdownClickHandler(filteredStationName);
+                }}
+              >
+                {filteredStationName}
+              </div>
+            ))}
+          </div>
+          <button
+            className="DetailStationSearchDropdownButton"
+            type="button"
+            onClick={dropdownCloseHandler}
+          >
+            x
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export default DetailStationSearchDropdown;

--- a/src/header/DetailStationSearchInput.tsx
+++ b/src/header/DetailStationSearchInput.tsx
@@ -1,0 +1,54 @@
+import { FaSearch } from 'react-icons/fa';
+import { useSetRecoilState } from 'recoil';
+import { currentStationAtom, isDropdownAtom } from '../recoil/atoms';
+import { IDetailStationSearchInputProps } from '../interfaces/interfaces';
+
+function DetailStationSearchInput({
+  searchInput,
+  stationNames,
+  setSearchInput,
+  setFilteredStationNames,
+}: IDetailStationSearchInputProps) {
+  const setIsDropdown = useSetRecoilState(isDropdownAtom);
+  const setCurrentStation = useSetRecoilState(currentStationAtom);
+
+  const searchInputChangeHandler = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchInput(e.target.value);
+    if (e.target.value.replace(/(\s*)/g, '') === '') {
+      setFilteredStationNames(stationNames);
+    } else if (e.target.value.replace(/(\s*)/g, '') !== '') {
+      setFilteredStationNames(
+        stationNames.filter((stationName) =>
+          stationName.includes(e.target.value),
+        ),
+      );
+    }
+  };
+
+  const searchClickHandler = () => {
+    setCurrentStation(searchInput.replace(/(\s*)/g, ''));
+  };
+
+  const inputOnFocusHandler = () => {
+    setIsDropdown(true);
+  };
+
+  return (
+    <div className="DetailStationSearch">
+      <input
+        className="DetailStationSearchInput"
+        placeholder="역명 검색"
+        onChange={searchInputChangeHandler}
+        value={searchInput}
+        onFocus={inputOnFocusHandler}
+      />
+      <FaSearch
+        className="DetailStationSearchIcon"
+        size="24"
+        onClick={searchClickHandler}
+      />
+    </div>
+  );
+}
+
+export default DetailStationSearchInput;

--- a/src/interfaces/interfaces.ts
+++ b/src/interfaces/interfaces.ts
@@ -1,3 +1,8 @@
+export interface IDetailStationLineButtonProps {
+  value: string;
+  line: string;
+}
+
 export interface IDataInfo {
   line2: ILineDatasInfo;
   line4: ILineDatasInfo;

--- a/src/interfaces/interfaces.ts
+++ b/src/interfaces/interfaces.ts
@@ -1,3 +1,14 @@
+export interface IDetailStationSearchDropdownProps {
+  filteredStationNames: string[];
+}
+
+export interface IDetailStationSearchInputProps {
+  searchInput: string;
+  stationNames: string[];
+  setSearchInput: (state: string) => void;
+  setFilteredStationNames: (state: string[]) => void;
+}
+
 export interface IDetailStationLineButtonProps {
   value: string;
   line: string;


### PR DESCRIPTION
## 한 것들
- [x] DetailStationLineButton 컴포넌트에 있던 interface 코드를 interface.ts 파일로 이동 시켰습니다.
- [x] DetailStationLineButton 컴포넌트에 분리되어있던 lineSelectAtom의 value와 상태 변환 함수를 함께 작성하여 한 줄로 처리하였습니다.
- [x] header의 DetailStationSearch 파일을 컴포넌트 분리 작업을 하여 더욱 세분화 하였습니다.
- [x] header의 DetailStationSearch 파일을 컴포넌트 분리 작업을 하면서 생긴 props에 타입을 지정해 줬습니다.